### PR TITLE
refactor(installation): use ansible instead of bash scripts for binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ To install GNU Stow on Linux, follow these steps (Debian/Ubuntu):
 
 ```bash
 sudo apt update
-sudo apt install stow
+sudo apt install stow ansible
+```
+
+## Install tools using ansible
+
+```bash
+ANSIBLE_FORCE_COLOR=True ansible-pull --url https://github.com/import-benjamin/.dotfiles.git --inventory localhost, --limit localhost --connection local  --verbose playbook.yml
 ```
 
 

--- a/fish/.config/fish/config.fish
+++ b/fish/.config/fish/config.fish
@@ -1,6 +1,8 @@
 fish_add_path ~/.cargo/bin
 fish_add_path ~/.npm-global/bin
 fish_add_path /opt/nvim-linux64/bin/
+fish_add_path /opt/lazygit-linux64/
+fish_add_path /opt/zellij-linux64/
 if status is-interactive
     # Commands to run in interactive sessions can go here
     set -g fish_key_bindings fish_vi_key_bindings

--- a/install-lazygit.sh
+++ b/install-lazygit.sh
@@ -1,4 +1,0 @@
-LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | \grep -Po '"tag_name": *"v\K[^"]*')
-curl -Lo lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz"
-tar xf lazygit.tar.gz lazygit
-sudo install lazygit -D -t /usr/local/bin/

--- a/install-nvim.sh
+++ b/install-nvim.sh
@@ -1,3 +1,0 @@
-curl -LO https://github.com/neovim/neovim/releases/download/nightly/nvim-macos-arm64.tar.gz
-tar xzf nvim-macos-arm64.tar.gz
-./nvim-macos-arm64/bin/nvim

--- a/install-zellij.sh
+++ b/install-zellij.sh
@@ -1,1 +1,0 @@
-cargo install --locked zellij

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,12 +2,10 @@
 
 - name: Install zellij
   hosts: all
-  connection: local
   tags:
     - cli
   tasks:
     - name: Check if zellij is installed
-      when: force_install is undefined
       ansible.builtin.shell: command -v zellij
       when: force_install is undefined
       changed_when: false
@@ -32,7 +30,6 @@
 
 - name: Install nvim
   hosts: all
-  connection: local
   tags:
     - cli
   tasks:
@@ -64,7 +61,6 @@
 
 - name: Install lazygit
   hosts: all
-  connection: local
   tags:
     - cli
   tasks:

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install zellij
-  hosts: localhost
+  hosts: all
   connection: local
   tags:
     - cli
@@ -31,7 +31,7 @@
         remote_src: yes
 
 - name: Install nvim
-  hosts: localhost
+  hosts: all
   connection: local
   tags:
     - cli
@@ -63,7 +63,7 @@
         remote_src: yes
 
 - name: Install lazygit
-  hosts: localhost
+  hosts: all
   connection: local
   tags:
     - cli

--- a/setup.yaml
+++ b/setup.yaml
@@ -1,0 +1,105 @@
+---
+
+- name: Install zellij
+  hosts: localhost
+  connection: local
+  tags:
+    - cli
+  tasks:
+    - name: Check if zellij is installed
+      when: force_install is undefined
+      ansible.builtin.shell: command -v zellij
+      when: force_install is undefined
+      changed_when: false
+      register: zellij_exists
+      ignore_errors: yes
+
+    - name: create binary folder
+      ansible.builtin.file:
+        path: /opt/zellij-linux64
+        state: directory
+      when: force_install is not undefined or zellij_exists is failed
+      register: folder_creation
+      become: true
+
+    - name: Extract latest zellij release
+      become: true
+      when: force_install is not undefined or zellij_exists is failed
+      ansible.builtin.unarchive:
+        src: https://github.com/zellij-org/zellij/releases/download/v0.41.2/zellij-x86_64-unknown-linux-musl.tar.gz
+        dest: "{{ folder_creation.path }}"
+        remote_src: yes
+
+- name: Install nvim
+  hosts: localhost
+  connection: local
+  tags:
+    - cli
+  tasks:
+    - name: check if nvim is installed
+      ansible.builtin.shell: command -v nvim
+      changed_when: false
+      when: force_install is undefined
+      register: nvim_exists
+      ignore_errors: yes
+
+    - name: fetch latest version on github
+      when: force_install is not undefined or nvim_exists is failed
+      ansible.builtin.uri:
+        url: https://api.github.com/repos/neovim/neovim/releases/latest
+        method: GET
+        return_content: yes
+        status_code: 200
+        body_format: json
+      register: nvim_version
+      retries: 3
+
+    - name: Extract latest nvim release
+      become: true
+      when: force_install is not undefined or nvim_exists is failed
+      ansible.builtin.unarchive:
+        src: https://github.com/neovim/neovim/releases/download/{{ nvim_version.json.tag_name }}/nvim-linux64.tar.gz
+        dest: /opt
+        remote_src: yes
+
+- name: Install lazygit
+  hosts: localhost
+  connection: local
+  tags:
+    - cli
+  tasks:
+
+    - name: check if lazygit is installed
+      ansible.builtin.shell: command -v lazygit
+      when: force_install is undefined
+      changed_when: false
+      register: lazygit_exists
+      ignore_errors: yes
+
+    - name: fetch latest version on github
+      when: force_install is not undefined or lazygit_exists is failed
+      ansible.builtin.uri:
+        url: https://api.github.com/repos/jesseduffield/lazygit/releases/latest
+        method: GET
+        return_content: yes
+        status_code: 200
+        body_format: json
+      register: lazygit_version
+      retries: 3
+
+    - name: Create bin folder
+      ansible.builtin.file:
+        path: /opt/lazygit-linux64
+        state: directory
+      when: force_install is not undefined or lazygit_exists is failed
+      become: true
+      register: folder_creation
+
+    - name: "Extract lazygit {{ lazygit_version.json.tag_name }} at {{ folder_creation.path | default('[skipped]')}}"
+      when: force_install is not undefined or lazygit_exists is failed
+      ansible.builtin.unarchive:
+        src: "https://github.com/jesseduffield/lazygit/releases/download/{{ lazygit_version.json.tag_name }}/lazygit_{{ lazygit_version.json.tag_name[1:] }}_Linux_x86_64.tar.gz"
+        dest: "{{ folder_creation.path }}"
+        remote_src: yes
+      become: true
+


### PR DESCRIPTION
Install zellij, nvim and lazygit using an ansible playbook.